### PR TITLE
162393612 Add DELETE api endpoint to delete red-flag record

### DIFF
--- a/server/controllers/redFlags.js
+++ b/server/controllers/redFlags.js
@@ -92,6 +92,26 @@
 			}]
 		});
 	}
+
+	deleteRedFlag (req, res) {
+		let id = Number(req.params.id);
+		const redFlag = data.find(redFlagData => redFlagData.id === id);
+
+		if(!redFlag){
+			return res.status(404).json({
+				status: 404,
+				error: 'red-flag record not found'
+			});
+		}
+		const position = data.indexOf(redFlag);
+		data.splice(position, 1);
+		res.json({
+			status: 200,
+			data: redFlag.id,
+			message : 'red-flag record has been deleted'
+		})
+
+	}
 }
 
 export default new RedFlags();

--- a/server/controllers/redFlags.js
+++ b/server/controllers/redFlags.js
@@ -31,14 +31,14 @@
 		const lastData = data[data.length - 1];
 		const newData = {
 			id: lastData.id + 1,
-    		createdOn: new Date().toString(),
-    		createdBy: lastData.createdBy + 1,
-    		type: 'red-flag', 
-    		location, 
-    		status: 'Pending',
-    		Images: ['video1', 'video2'],
-    		Videos: ['image1', 'image2'],
-    		comment
+    			createdOn: new Date().toString(),
+    			createdBy: lastData.createdBy + 1,
+    			type: 'red-flag', 
+    			location, 
+    			status: 'Pending',
+    			Images: ['video1', 'video2'],
+    			Videos: ['image1', 'image2'],
+    			comment
 		}
 
 		data.push(newData)

--- a/server/routes/red-flags.js
+++ b/server/routes/red-flags.js
@@ -14,5 +14,7 @@ router.patch('/red-flags/:id/location', midware.validateLocation, redFlags.editL
 
 router.patch('/red-flags/:id/comment',midware.validateComment, redFlags.editComment);
 
+router.delete('/red-flags/:id', redFlags.deleteRedFlag);
+
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
Enables user to delete a red-flag record

#### Description of Task to be completed?
Get the following api endpoint working:
DELETE /api/v1/red-flags

#### How should this be manually tested?
After starting local server, use Postman to make a DELETE request to the following address:
localhost:3000/api/v1/red-flags/<red-flag id> 

#### What are the relevant pivotal tracker stories?
162393612